### PR TITLE
Adding all transports to the AVM MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# AVM MCP Server Configuration
+# Copy this file to .env and modify as needed
+
+# Server host (use 0.0.0.0 to bind to all interfaces, or 127.0.0.1 for localhost only)
+MCP_HOST=0.0.0.0
+
+# Server port
+MCP_PORT=8080
+
+# Debug mode (true/false)
+MCP_DEBUG=false
+
+# Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.13.2-slim
+
+WORKDIR /app
+
+# Copy the requirements.txt file into the container
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["python", "server.py", "--transport=http", "--port=8080"]

--- a/README.md
+++ b/README.md
@@ -275,6 +275,84 @@ If you cloned the repository:
 uv run .\server.py
 ```
 
+### Running with Different Transports
+
+The server now supports multiple transport methods for different use cases:
+
+#### 1. STDIO Transport (Default)
+
+Standard input/output - ideal for Claude Desktop and MCP Inspector:
+
+```bash
+python server.py --transport stdio
+```
+
+This is the default mode and is used when no transport is specified.
+
+#### 2. HTTP Transport
+
+Streamable HTTP transport - ideal for web applications and REST API integrations:
+
+```bash
+python server.py --transport http --host 0.0.0.0 --port 8080
+```
+
+Test the server is running:
+```bash
+# Simple tools listing endpoint (GET request)
+curl http://localhost:8080/tools
+
+# MCP protocol endpoint (requires POST with JSON-RPC format)
+curl -X POST http://localhost:8080/mcp/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {},
+      "clientInfo": {"name": "test-client", "version": "1.0.0"}
+    }
+  }'
+```
+
+**Note**: The MCP endpoint (`/mcp/`) requires a trailing slash and expects POST requests with JSON-RPC formatted data. For easier testing, use the convenience tools endpoint (`/tools`) or the example script:
+
+```bash
+python example_http_usage.py
+```
+
+#### 3. SSE Transport
+
+Server-Sent Events transport - ideal for real-time streaming applications:
+
+```bash
+python server.py --transport sse --host 0.0.0.0 --port 8080
+```
+
+#### Additional Options
+
+- `--debug`: Enable debug logging
+- `--host`: Host address to bind to (default: 0.0.0.0 for HTTP/SSE)
+- `--port`: Port to use (default: 8080 for HTTP/SSE)
+
+Example with debug mode:
+```bash
+python server.py --transport http --port 8081 --debug
+```
+
+#### Configuration via Environment Variables
+
+You can also configure the server using a `.env` file:
+
+```env
+MCP_HOST=0.0.0.0
+MCP_PORT=8080
+MCP_DEBUG=false
+LOG_LEVEL=INFO
+```
+
 ### Inspect MCP Server
 
 Using the MCP Inspector with uvx:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,46 @@
+"""Configuration settings for the AVM MCP Server."""
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings."""
+    
+    # Server configuration
+    MCP_HOST: str = "0.0.0.0"
+    MCP_PORT: int = 8080
+    MCP_DEBUG: bool = False
+    
+    # Logging configuration
+    LOG_LEVEL: str = "INFO"
+    
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+
+# Create a global settings instance
+settings = Settings()
+
+
+# Logging configuration
+logging_config = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "default",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "root": {
+        "level": settings.LOG_LEVEL,
+        "handlers": ["console"],
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,19 @@
+# Core dependencies
+requests>=2.28.0
+fastapi>=0.89.0
+uvicorn>=0.20.0
+starlette>=0.25.0
+pydantic>=1.10.0
+
+# MCP server
+mcp-server>=0.1.0
+
+# MCP transport dependencies
+anyio>=3.6.0
+nest-asyncio>=1.5.6
+
+# Utilities
+tabulate>=0.9.0
+python-dotenv>=0.21.0
 fastmcp
-requests
+pydantic-settings

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Setup script for AVM MCP Server with multi-transport support
+
+echo "=========================================="
+echo "AVM MCP Server - Setup Script"
+echo "=========================================="
+echo ""
+
+# Check if Python is installed
+if ! command -v python3 &> /dev/null; then
+    echo "❌ Python 3 is not installed. Please install Python 3.11 or later."
+    exit 1
+fi
+
+echo "✅ Python 3 found: $(python3 --version)"
+echo ""
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+    echo "📦 Creating virtual environment..."
+    python3 -m venv .venv
+    echo "✅ Virtual environment created"
+else
+    echo "✅ Virtual environment already exists"
+fi
+echo ""
+
+# Activate virtual environment
+echo "🔧 Activating virtual environment..."
+source .venv/bin/activate
+echo "✅ Virtual environment activated"
+echo ""
+
+# Upgrade pip
+echo "📦 Upgrading pip..."
+pip install --upgrade pip
+echo ""
+
+# Install dependencies
+echo "📦 Installing dependencies..."
+pip install -r requirements.txt
+echo "✅ Dependencies installed"
+echo ""
+
+# Test import
+echo "🧪 Testing imports..."
+python3 -c "
+import logging
+import requests
+print('✅ Basic imports successful')
+try:
+    from mcp.server.fastmcp import FastMCP
+    print('✅ FastMCP import successful')
+except ImportError as e:
+    print(f'⚠️  FastMCP import issue: {e}')
+    print('   This is expected if fastmcp is not properly installed')
+"
+echo ""
+
+echo "=========================================="
+echo "Setup Complete!"
+echo "=========================================="
+echo ""
+echo "To run the server:"
+echo "  STDIO mode (default):  python server.py"
+echo "  HTTP mode:             python server.py --transport http"
+echo "  SSE mode:              python server.py --transport sse"
+echo "  With debug:            python server.py --transport http --debug"
+echo ""
+echo "To test HTTP transport:"
+echo "  python test_transports.py"
+echo ""


### PR DESCRIPTION
This PR adds all different transports supported by the MCP protocol as a switch for the startup code, and it includes a Dockerfile for containerised operation